### PR TITLE
Update allowed hosts for disallowed host error

### DIFF
--- a/fitness_journal/settings.py
+++ b/fitness_journal/settings.py
@@ -25,7 +25,19 @@ SECRET_KEY = 'django-insecure-8v=04r(5#1t7s!d=uq#tltvy$cjp-0hx72jjb3da%8ml6f&#%j
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+
+# Allow Render.com external hostnames
+render_hostname = os.environ.get('RENDER_EXTERNAL_HOSTNAME')
+if render_hostname:
+    ALLOWED_HOSTS.append(render_hostname)
+    # Also allow subdomains of the same host just in case
+    if '.' in render_hostname:
+        domain_parts = render_hostname.split('.')
+        if len(domain_parts) > 2:
+            # keep the last two parts as base domain e.g. onrender.com
+            base_domain = '.'.join(domain_parts[-2:])
+            ALLOWED_HOSTS.append(f'.{base_domain}')
 
 
 # Application definition


### PR DESCRIPTION
Add Render.com hostname and local development hosts to `ALLOWED_HOSTS` to resolve `DisallowedHost` errors on deployment.

The deployed site was failing with `django.core.exceptions.DisallowedHost` because the `ALLOWED_HOSTS` setting was empty. This change configures `ALLOWED_HOSTS` to include common local development hosts and dynamically adds the Render.com external hostname and its base domain, ensuring the application functions correctly in both development and production environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-a40714fd-90fa-4902-aad5-2537f31d5206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a40714fd-90fa-4902-aad5-2537f31d5206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

