### PR TITLE
Update allowed hosts for disallowed host error

### DIFF
--- a/fitness_journal/settings.py
+++ b/fitness_journal/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-8v=04r(5#1t7s!d=uq#tltvy$cjp-0hx72jjb3da%8ml6f&#%j
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['fitnessjournalgain.onrender.com', '.onrender.com', 'localhost', '127.0.0.1']
 
 
 # Application definition

--- a/fitness_journal/settings_production.py
+++ b/fitness_journal/settings_production.py
@@ -12,7 +12,16 @@ DEBUG = False
 SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-8v=04r(5#1t7s!d=uq#tltvy$cjp-0hx72jjb3da%8ml6f&#%j')
 
 # Update allowed hosts for production
-ALLOWED_HOSTS = ['*']  # You can restrict this to your specific domain later
+ALLOWED_HOSTS = ['fitnessjournalgain.onrender.com', '.onrender.com', 'localhost', '127.0.0.1']
+
+# Trust the Render domain for CSRF (scheme required)
+CSRF_TRUSTED_ORIGINS = [
+    'https://fitnessjournalgain.onrender.com',
+    'https://*.onrender.com',
+]
+
+# Honor X-Forwarded-Proto header set by the proxy (e.g., Render)
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Database configuration for production
 DATABASES = {


### PR DESCRIPTION
Add Render domain to `ALLOWED_HOSTS` and configure proxy/CSRF settings to resolve `DisallowedHost` errors.

The `DisallowedHost` error occurred because Django's `ALLOWED_HOSTS` setting did not include the Render deployment URL. `CSRF_TRUSTED_ORIGINS` and `SECURE_PROXY_SSL_HEADER` are also added for proper handling of requests when deployed behind a reverse proxy like Render, ensuring secure POST requests and correct HTTPS detection.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1f2c059-eebf-405f-90f3-c279b8943d7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1f2c059-eebf-405f-90f3-c279b8943d7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

